### PR TITLE
Introduce A-Z Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,19 @@ waitress-serve --port=$PORT parkrun_map.map_app:map_app.server
 echo "paste http://0.0.0.0:$PORT into your browser"
 ```
 
+## A-Z Mode <sup>[NEW]</sup>
+
+This mode shows you how far progressed you are through the "parkrun A-Z", accessible via the "A-Z mode" checkbox.
+At a minimum it shows which letters the athlete has achieved (and which ones are still missing) by looking at the first
+letters of each event you have participated in. If "Show missing events" is also ticked, then A-Z mode filters it to
+show only those missing events that would give you a new letter (with the closest one for each remaining letter highlighted
+by being a bit bigger).
+
+Hopefully this mode will provide renewed focus for hungry parkrun conquistador(a)s - enjoy!
+
+
+![Example from the author](https://user-images.githubusercontent.com/13883308/263394817-581c9ff0-f14e-43db-92e9-c3f97ef7c523.png)
+
 ## About
 
 [![Parkrun logo](https://www.renfrewshireleisure.com/media/187953/parkrun-logo.jpg)](https://www.parkrun.com)

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -42,10 +42,10 @@ def get_graph(athlete_id, checkbox_options):
         # Filter only on junior events
         athlete_data = athlete_data[athlete_data['event_name'].apply(lambda name: '-juniors' in name)]
 
+    athlete_data['first_letter'] = athlete_data['event_title'].apply(lambda title: title[0].lower())
     if not show_missing:
         athlete_data = athlete_data[athlete_data['run_count'] > 0]
     elif az_mode:
-        athlete_data['first_letter'] = athlete_data['event_title'].apply(lambda title: title[0].lower())
         acquired_letters = sorted(list(set(athlete_data[athlete_data['run_count'] > 0]['first_letter'])))
         missing_letters = list(set(list(ascii_lowercase)) - set(acquired_letters))
         athlete_data = athlete_data[(athlete_data['run_count'] > 0) | (athlete_data['first_letter'].isin(missing_letters))]

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -43,8 +43,12 @@ def get_graph(athlete_id, checkbox_options):
         # Filter only on junior events
         athlete_data = athlete_data[athlete_data['event_name'].apply(lambda name: '-juniors' in name)]
 
-    athlete_data['first_letter'] = athlete_data['event_title'].apply(lambda title: title[0].lower())
+    athlete_data['event_title_pretty'] = athlete_data['event_title'].apply(
+        lambda title: title.replace('parkrun', '').replace('junior', 'Juniors').replace(' ,', ',').strip()
+    )
+    athlete_data['first_letter'] = athlete_data['event_title_pretty'].apply(lambda title: title[0].lower())
     acquired_letters = sorted(list(set(athlete_data[athlete_data['run_count'] > 0]['first_letter'])))
+
     if not show_missing:
         athlete_data = athlete_data[athlete_data['run_count'] > 0]
     elif az_mode:
@@ -52,9 +56,6 @@ def get_graph(athlete_id, checkbox_options):
         athlete_data = athlete_data[(athlete_data['run_count'] > 0) | (athlete_data['first_letter'].isin(missing_letters))]
 
     # Extra tweaks for prettiness
-    athlete_data['event_title_pretty'] = athlete_data['event_title'].apply(
-        lambda title: title.replace('parkrun', '').replace('junior', 'Juniors').replace(' ,', ',').strip()
-    )
     athlete_data['marker_color'] = athlete_data['run_count'].apply(lambda count: COLOUR_MISSING if count == 0 else COLOUR_COMPLETE)
     athlete_data['marker_opacity'] = athlete_data['run_count'].apply(lambda count: 0.33 if count == 0 else 1)
 
@@ -80,7 +81,7 @@ def get_graph(athlete_id, checkbox_options):
             opacity=1
         ),
         text=athlete_data_complete['event_title_pretty'],
-        hovertemplate='<b>%{customdata[8]}</b><br><br>Run count = %{customdata[2]:.0f}<br>Personal best = %{customdata[3]}<extra></extra>'
+        hovertemplate='<b>%{customdata[7]}</b><br><br>Run count = %{customdata[2]:.0f}<br>Personal best = %{customdata[3]}<extra></extra>'
     ))
 
     if len(athlete_data_missing) > 0:

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -43,11 +43,10 @@ def get_graph(athlete_id, checkbox_options):
         athlete_data = athlete_data[athlete_data['event_name'].apply(lambda name: '-juniors' in name)]
 
     athlete_data['first_letter'] = athlete_data['event_title'].apply(lambda title: title[0].lower())
-    acquired_letters = []
+    acquired_letters = sorted(list(set(athlete_data[athlete_data['run_count'] > 0]['first_letter'])))
     if not show_missing:
         athlete_data = athlete_data[athlete_data['run_count'] > 0]
     elif az_mode:
-        acquired_letters = sorted(list(set(athlete_data[athlete_data['run_count'] > 0]['first_letter'])))
         missing_letters = list(set(list(ascii_lowercase)) - set(acquired_letters))
         athlete_data = athlete_data[(athlete_data['run_count'] > 0) | (athlete_data['first_letter'].isin(missing_letters))]
 

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -151,7 +151,8 @@ map_app.layout = html.Div([
     ),
     html.Div(
         id='letters',
-        children=[html.B(letter.upper(), style={'color': COLOUR_MISSING}, id=f'letter_{letter}') for letter in ascii_lowercase],
+        children=[html.B(letter.upper(), style={'color': COLOUR_MISSING}, id=f'letter_{letter}') for letter in ascii_lowercase] +
+                 [html.B(f' (0 / 26)', style={'color': COLOUR_COMPLETE}, id='letter_total')],
         style={'display': 'none'},
     ),
     html.Div(id='map_wrapper', children=dcc.Graph(id='map', figure=base_figure, config={'displayModeBar': False})),
@@ -194,14 +195,14 @@ def reload_map(_map, athlete_id, checkbox_options):
 
 
 @map_app.callback(
-    [Output(f'letter_{letter}', 'style') for letter in ascii_lowercase],
+    [Output(f'letter_{letter}', 'style') for letter in ascii_lowercase] + [Output('letter_total', 'children')],
     [Input('az_store', 'data')]
 )
 def update_acquired_letter(acquired_letters: List[str]):
     return [
         {'color': COLOUR_COMPLETE} if letter in acquired_letters else {'color': COLOUR_MISSING}
         for letter in ascii_lowercase
-    ]
+    ] + [f' ({len(acquired_letters)} / 26)']
 
 
 if __name__ == "__main__":

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -1,6 +1,6 @@
 import argparse
 from math import sqrt
-from string import ascii_lowercase
+from string import ascii_lowercase, ascii_uppercase
 
 import dash
 from dash import dcc
@@ -147,6 +147,11 @@ map_app.layout = html.Div([
         ],
         value=['show_parkruns'],
         labelStyle={'display': 'inline-block'}
+    ),
+    html.Div(
+        id='letters',
+        children=[html.B(letter, style={'color': COLOUR_MISSING}, id=f'letter_{letter}') for letter in ascii_uppercase],
+        style={'display': 'none'},
     ),
     html.Div(id='map_wrapper', children=dcc.Graph(id='map', figure=base_figure, config={'displayModeBar': False})),
 ])

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -1,6 +1,7 @@
 import argparse
 from math import sqrt
 from string import ascii_lowercase
+from typing import List
 
 import dash
 from dash import dcc
@@ -190,6 +191,17 @@ def reload_map(_map, athlete_id, checkbox_options):
         return html.Div(id='map', children=dcc.Graph(figure=fig, config={'displayModeBar': False}))
     else:
         raise dash.exceptions.PreventUpdate()
+
+
+@map_app.callback(
+    [Output(f'letter_{letter}', 'style') for letter in ascii_lowercase],
+    [Input('az_store', 'data')]
+)
+def update_acquired_letter(acquired_letters: List[str]):
+    return [
+        {'color': COLOUR_COMPLETE} if letter in acquired_letters else {'color': COLOUR_MISSING}
+        for letter in ascii_lowercase
+    ]
 
 
 if __name__ == "__main__":

--- a/parkrun_map/map_app.py
+++ b/parkrun_map/map_app.py
@@ -1,6 +1,6 @@
 import argparse
 from math import sqrt
-from string import ascii_lowercase, ascii_uppercase
+from string import ascii_lowercase
 
 import dash
 from dash import dcc
@@ -151,7 +151,7 @@ map_app.layout = html.Div([
     ),
     html.Div(
         id='letters',
-        children=[html.B(letter, style={'color': COLOUR_MISSING}, id=f'letter_{letter}') for letter in ascii_uppercase],
+        children=[html.B(letter.upper(), style={'color': COLOUR_MISSING}, id=f'letter_{letter}') for letter in ascii_lowercase],
         style={'display': 'none'},
     ),
     html.Div(id='map_wrapper', children=dcc.Graph(id='map', figure=base_figure, config={'displayModeBar': False})),


### PR DESCRIPTION
This change introduces a new checkbox which, when ticked, shows you how far progressed you are through the "parkrun A-Z". 

At a minimum it shows which letters the athlete has achieved (and which ones are still missing). If you have show missing events also checked, A-Z mode filters it to show only those that would give you a new letter (with the closest one for each remaining letter highlighted by being a bit bigger). 

Hopefully this mode will provide renewed focus for hungry parkrun conquistadors - enjoy!